### PR TITLE
Fix false positive when detecting https.

### DIFF
--- a/configs.php
+++ b/configs.php
@@ -7,7 +7,7 @@ $config->website->name = "TorrentCaching";
 
 $url = $_SERVER['HTTP_HOST'];
 $url = rtrim($url, '/') . '/';
-if (isset($_SERVER['HTTPS']))
+if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == "on")
     $url = "https://" . $url;
 else if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == "https")
     $url = "https://" . $url;


### PR DESCRIPTION
PHP is dumb.  `$_SERVER['HTTPS']` is set to `""` ([sometimes even](https://stackoverflow.com/questions/7304182/detecting-ssl-with-php/7304205#7304205) `"off"`!) when using plain old http, and `"on"` when it's using https.
