### PR TITLE
Fix .torrent links

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule .* - [L]
 
-RewriteRule ^(torrent\/)?([0-F]{40}+)(\.torrent)?/?$ index.php?page_url=$2 [NC,QSA,L]
+RewriteRule ^(torrent\/)?([0-F]{40})(\.torrent)?/?$ index.php?page_url=$2 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)/?$ index.php?page_url=$1 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ index.php?page_url=$1&page_action=$2 [NC,QSA,L]
 

--- a/README.txt
+++ b/README.txt
@@ -5,6 +5,7 @@ RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule .* - [L]
 
+RewriteRule ^(torrent\/)?([0-F]{40}+)(\.torrent)?/?$ index.php?page_url=$2 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)/?$ index.php?page_url=$1 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ index.php?page_url=$1&page_action=$2 [NC,QSA,L]
 
@@ -19,5 +20,6 @@ set $rule_0 1;
 }
 if ($rule_0 = "1"){
 }
+rewrite "^/(torrent/)?([0-F]{40})(\.torrent)?$" /index.php?page_url=$2 last;
 rewrite ^/([_A-Za-z0-9-]+)/?$ /index.php?page_url=$1 last;
 rewrite ^/([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ /index.php?page_url=$1&page_action=$2 last;

--- a/api/upload.php
+++ b/api/upload.php
@@ -31,7 +31,7 @@ if (isset($_POST['upload'])) {
         $file_path = _configs()->paths->torrents . $filename;
         $magnet_link = 'magnet:?xt=urn:btih:' . $infohash . "&tr=" . implode("&tr=", _configs()->trackers);
 
-        if (move_uploaded_file($file['tmp_name'], $file_path)) {
+        if (move_uploaded_file($file['tmp_name'], $file_path . '.torrent')) {
             $array = array(
                 "error" => false,
                 "message" => "The torrent has been successfully uploaded",

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@ define("PAGE_ACTION", isset($_GET['page_action']) ? $_GET['page_action'] : "main
 
 if (preg_match("/^([0-F]{40})\.torrent/i", PAGE_URL.".torrent") && file_exists(_configs()->paths->torrents . PAGE_URL.".torrent")) {
     $file = file_get_contents(_configs()->paths->torrents . PAGE_URL.".torrent");
-    header('Content-Disposition: attachment; filename="' . PAGE_URL . '"');
+    header('Content-Disposition: attachment; filename="' . PAGE_URL . '.torrent"');
     header("Content-Type: application/x-bittorrent");
     die($file);
 } else {

--- a/pages/docs/main.php
+++ b/pages/docs/main.php
@@ -30,7 +30,7 @@
         "error" => false,
         "message" => "The torrent has been successfully uploaded",
         "url" => _configs()->website->url . "torrent/" . strtoupper(sha1("dexter.s03.e07")) . ".torrent",
-        "magnet" => "magnet:?xt=urn:btih:" . strtoupper(sha1("dexter.s03.e07")) . _configs()->trackers
+        "magnet" => "magnet:?xt=urn:btih:" . strtoupper(sha1("dexter.s03.e07")) . "&tr=" . implode("&tr=", _configs()->trackers)
     );
     echo json_encode($array);
 ?>

--- a/pages/upload/main.php
+++ b/pages/upload/main.php
@@ -35,7 +35,7 @@ if (isset($_POST['upload'])) {
         $file_path = _configs()->paths->torrents . $filename;
         $magnet_link = 'magnet:?xt=urn:btih:' . $infohash . "&tr=" . implode("&tr=", _configs()->trackers);
 
-        if (move_uploaded_file($file['tmp_name'], $file_path)) {
+        if (move_uploaded_file($file['tmp_name'], $file_path . '.torrent')) {
             echo "<div class='alert alert-success'>The torrent has been successfully uploaded, to download it follow the link below<br />  <a href='" . _configs()->website->url . $filename . "'>" . _configs()->website->url . $filename . "</a><br /><a href='" . $magnet_link . "'>Magnet link</a></div>";
         }
     } Catch (Exception $e) {


### PR DESCRIPTION
Version 2 broke all external links (eg, http://example.com/torrent/7ED0137D09E1FE26B39F5E650B2F9DEE08F3E2F4.torrent).  Additionally, the files were stored without the '.torrent' extension.  Clicking the download link after uploading a torrent gave a "File not Found" error because of this.

These changes re-add the ".torrent" extension to the file stored on the server, as well as the file that is sent to the client.  This does not break the new torrent links (eg, http://example.com/7ED0137D09E1FE26B39F5E650B2F9DEE08F3E2F4) nor change the link displayed upon upload.  The additional rewrite rule enables both the old link format, as well as the new one with or without ".torrent" appended.

I am unable to test the Apache RewriteRule addition, but there shouldn't be any issues.
