### PR TITLE
Torrent as text

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,7 +6,7 @@ RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule .* - [L]
 
-RewriteRule ^(torrent\/)?([0-F]{40})(\.torrent)?/?$ index.php?page_url=$2 [NC,QSA,L]
+RewriteRule ^(torrent|text)?\/?([0-F]{40})(\.torrent)?/?$ index.php?page_url=$2&page_action=$2 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)/?$ index.php?page_url=$1 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ index.php?page_url=$1&page_action=$2 [NC,QSA,L]
 

--- a/.htaccess
+++ b/.htaccess
@@ -1,10 +1,12 @@
 <IfModule mod_rewrite.c>
 
 RewriteEngine On
+RewriteBase /
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule .* - [L]
 
+RewriteRule ^(torrent\/)?([0-F]{40})(\.torrent)?/?$ index.php?page_url=$2 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)/?$ index.php?page_url=$1 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ index.php?page_url=$1&page_action=$2 [NC,QSA,L]
 

--- a/.htaccess
+++ b/.htaccess
@@ -6,7 +6,7 @@ RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule .* - [L]
 
-RewriteRule ^(torrent|text)?\/?([0-F]{40})(\.torrent)?/?$ index.php?page_url=$2&page_action=$2 [NC,QSA,L]
+RewriteRule ^(torrent|text)?\/?([0-F]{40})(\.torrent)?/?$ index.php?page_url=$2&page_action=$1 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)/?$ index.php?page_url=$1 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ index.php?page_url=$1&page_action=$2 [NC,QSA,L]
 

--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,7 @@ RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule .* - [L]
 
-RewriteRule ^(torrent\/)?([0-F]{40})(\.torrent)?/?$ index.php?page_url=$2 [NC,QSA,L]
+RewriteRule ^(torrent|text)?\/?([0-F]{40})(\.torrent)?/?$ index.php?page_url=$2&page_action=$2 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)/?$ index.php?page_url=$1 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ index.php?page_url=$1&page_action=$2 [NC,QSA,L]
 
@@ -14,6 +14,6 @@ RewriteRule ^([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ index.php?page_url=$1&page_ac
 nginx rewrite rules
 ===================
 
-rewrite "^/(torrent/)?([0-F]{40})(\.torrent)?$" /index.php?page_url=$2 last;
+rewrite "^/(torrent|text)?\/?([0-F]{40})(\.torrent)?$" /index.php?page_url=$2&page_action=$1 last;
 rewrite ^/([_A-Za-z0-9-]+)/?$ /index.php?page_url=$1 last;
 rewrite ^/([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ /index.php?page_url=$1&page_action=$2 last;

--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,7 @@
 Apache rewrite rules
-
+====================
 RewriteEngine On
+RewriteBase /
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule .* - [L]
@@ -11,15 +12,8 @@ RewriteRule ^([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ index.php?page_url=$1&page_ac
 
 
 nginx rewrite rules
+===================
 
-if (-f $request_filename){
-set $rule_0 1;
-}
-if (-d $request_filename){
-set $rule_0 1;
-}
-if ($rule_0 = "1"){
-}
 rewrite "^/(torrent/)?([0-F]{40})(\.torrent)?$" /index.php?page_url=$2 last;
 rewrite ^/([_A-Za-z0-9-]+)/?$ /index.php?page_url=$1 last;
 rewrite ^/([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ /index.php?page_url=$1&page_action=$2 last;

--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,7 @@ RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule .* - [L]
 
-RewriteRule ^(torrent|text)?\/?([0-F]{40})(\.torrent)?/?$ index.php?page_url=$2&page_action=$2 [NC,QSA,L]
+RewriteRule ^(torrent|text)?\/?([0-F]{40})(\.torrent)?/?$ index.php?page_url=$2&page_action=$1 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)/?$ index.php?page_url=$1 [NC,QSA,L]
 RewriteRule ^([_A-Za-z0-9-]+)\/([_A-Za-z0-9-]+)/?$ index.php?page_url=$1&page_action=$2 [NC,QSA,L]
 

--- a/index.php
+++ b/index.php
@@ -8,8 +8,13 @@ define("PAGE_ACTION", isset($_GET['page_action']) ? $_GET['page_action'] : "main
 
 if (preg_match("/^([0-F]{40})\.torrent/i", PAGE_URL.".torrent") && file_exists(_configs()->paths->torrents . PAGE_URL.".torrent")) {
     $file = file_get_contents(_configs()->paths->torrents . PAGE_URL.".torrent");
-    header('Content-Disposition: attachment; filename="' . PAGE_URL . '.torrent"');
-    header("Content-Type: application/x-bittorrent");
+	if (PAGE_ACTION == 'text') {
+		header('Content-Disposition: attachment; filename="' . PAGE_URL . '.txt"');
+		header("Content-Type: text/plain");
+	} else {
+		header('Content-Disposition: attachment; filename="' . PAGE_URL . '.torrent"');
+		header("Content-Type: application/x-bittorrent");
+	}
     die($file);
 } else {
     $tpl = new Template(_configs()->paths->template . "template.php");

--- a/pages/upload/main.php
+++ b/pages/upload/main.php
@@ -36,7 +36,7 @@ if (isset($_POST['upload'])) {
         $magnet_link = 'magnet:?xt=urn:btih:' . $infohash . "&tr=" . implode("&tr=", _configs()->trackers);
 
         if (move_uploaded_file($file['tmp_name'], $file_path . '.torrent')) {
-            echo "<div class='alert alert-success'>The torrent has been successfully uploaded, to download it follow the link below<br />  <a href='" . _configs()->website->url . $filename . "'>" . _configs()->website->url . $filename . "</a><br /><a href='" . $magnet_link . "'>Magnet link</a> | <a href='". _configs()->website->url . '/text/' . $filename . "'>Text</a></div>";
+            echo "<div class='alert alert-success'>The torrent has been successfully uploaded, to download it follow the link below<br />  <a href='" . _configs()->website->url . $filename . "'>" . _configs()->website->url . $filename . "</a><br /><a href='" . $magnet_link . "'>Magnet link</a> | <a href='". _configs()->website->url . 'text/' . $filename . "'>Text</a></div>";
         }
     } Catch (Exception $e) {
         echo $e->getMessage();

--- a/pages/upload/main.php
+++ b/pages/upload/main.php
@@ -36,7 +36,7 @@ if (isset($_POST['upload'])) {
         $magnet_link = 'magnet:?xt=urn:btih:' . $infohash . "&tr=" . implode("&tr=", _configs()->trackers);
 
         if (move_uploaded_file($file['tmp_name'], $file_path . '.torrent')) {
-            echo "<div class='alert alert-success'>The torrent has been successfully uploaded, to download it follow the link below<br />  <a href='" . _configs()->website->url . $filename . "'>" . _configs()->website->url . $filename . "</a><br /><a href='" . $magnet_link . "'>Magnet link</a></div>";
+            echo "<div class='alert alert-success'>The torrent has been successfully uploaded, to download it follow the link below<br />  <a href='" . _configs()->website->url . $filename . "'>" . _configs()->website->url . $filename . "</a><br /><a href='" . $magnet_link . "'>Magnet link</a> | <a href='". _configs()->website->url . '/text/' . $filename . "'>Text</a></div>";
         }
     } Catch (Exception $e) {
         echo $e->getMessage();


### PR DESCRIPTION
This adds a link to download a given torrent file as a plain text file.  Some firewalls and web filters block 'application/x-bittorrent' content types, and sending the torrent file as a text file circumvents this block.

The rewrite rules were tested with both nginx and Apache.  I've also removed the 'if' blocks from the nginx rules as they don't do anything and they are [evil according to the nginx devs](http://wiki.nginx.org/IfIsEvil).
